### PR TITLE
Fix unformatted module name placeholder in "Could not find the star imports" warning

### DIFF
--- a/removestar/removestar.py
+++ b/removestar/removestar.py
@@ -135,7 +135,7 @@ def replace_imports(code, repls, *, max_line_length=100, file=None, verbose=Fals
         new_code = STAR_IMPORT.sub(new_import, code)
         if new_code == code:
             if not quiet:
-                print("Warning: Could not find the star imports for '{mod}'", file=sys.stderr)
+                print(f"Warning: Could not find the star imports for '{mod}'", file=sys.stderr)
         elif verbose:
             msg = f"Replacing 'from {mod} import *' with '{new_import.strip()}'"
             if file:

--- a/removestar/removestar.py
+++ b/removestar/removestar.py
@@ -135,7 +135,8 @@ def replace_imports(code, repls, *, max_line_length=100, file=None, verbose=Fals
         new_code = STAR_IMPORT.sub(new_import, code)
         if new_code == code:
             if not quiet:
-                print(f"Warning: Could not find the star imports for '{mod}'", file=sys.stderr)
+                prefix = f"Warning: {file}:" if file else "Warning:"
+                print(f"{prefix} Could not find the star imports for '{mod}'", file=sys.stderr)
         elif verbose:
             msg = f"Replacing 'from {mod} import *' with '{new_import.strip()}'"
             if file:

--- a/removestar/tests/test_removestar.py
+++ b/removestar/tests/test_removestar.py
@@ -869,6 +869,29 @@ def test_replace_imports():
 
     assert replace_imports(code_mod_unfixable, repls={'.mod1': ['a'], '.mod2': ['c'], '.mod3': ['name']}) == code_mod_unfixable
 
+
+def test_replace_imports_warnings(capsys):
+    assert replace_imports(code_mod_unfixable, file='module/mod_unfixable.py', repls={'.mod1': ['a'], '.mod2': ['c'], '.mod3': ['name']}) == code_mod_unfixable
+    out, err = capsys.readouterr()
+    assert set(err.splitlines()) == {
+        "Warning: module/mod_unfixable.py: Could not find the star imports for '.mod1'",
+        "Warning: module/mod_unfixable.py: Could not find the star imports for '.mod2'",
+        "Warning: module/mod_unfixable.py: Could not find the star imports for '.mod3'"
+    }
+
+    assert replace_imports(code_mod_unfixable, file=None, repls={'.mod1': ['a'], '.mod2': ['c'], '.mod3': ['name']}) == code_mod_unfixable
+    out, err = capsys.readouterr()
+    assert set(err.splitlines()) == {
+        "Warning: Could not find the star imports for '.mod1'",
+        "Warning: Could not find the star imports for '.mod2'",
+        "Warning: Could not find the star imports for '.mod3'"
+    }
+
+    assert replace_imports(code_mod_unfixable, quiet=True, repls={'.mod1': ['a'], '.mod2': ['c'], '.mod3': ['name']}) == code_mod_unfixable
+    out, err = capsys.readouterr()
+    assert err == ''
+
+
 def test_replace_imports_line_wrapping():
     code = """\
 from reallyreallylongmodulename import *
@@ -980,9 +1003,9 @@ Warning: {directory}/mod4.py: 'b' comes from multiple modules: '.mod1', '.mod2'.
 Warning: {directory}/mod4.py: could not find import for 'd'
 Warning: {directory}/mod5.py: 'b' comes from multiple modules: 'module.mod1', 'module.mod2'. Using 'module.mod2'.
 Warning: {directory}/mod5.py: could not find import for 'd'
-Warning: Could not find the star imports for '.mod1'
-Warning: Could not find the star imports for '.mod2'
-Warning: Could not find the star imports for '.mod3'
+Warning: {directory}/mod_unfixable.py: Could not find the star imports for '.mod1'
+Warning: {directory}/mod_unfixable.py: Could not find the star imports for '.mod2'
+Warning: {directory}/mod_unfixable.py: Could not find the star imports for '.mod3'
 """.splitlines())
 
     error = f"Error with {directory}/mod_bad.py: SyntaxError: invalid syntax (mod_bad.py, line 1)"


### PR DESCRIPTION
I've found removestar really useful when fixing up a large codebase with loads of star imports, it saved me a bunch of time, thanks!

I noticed a bug in the warning message when removestar isn't able to replace the star import in the code. The fstring for the message is missing the leading `f`, so it's printing the warning without the `{mod}` placeholder being substituted:

```
Warning: Could not find the star imports for '{mod}'
```

This PR fixes that, and also adds the filename to the warning if it's available:

```
Warning: my/module.py: Could not find the star imports for 'foo.bar'
```

As an aside, the reason it was not able to replace some of the imports I had was that they had strange formatting. The tests I added have some examples. The `STAR_IMPORT` regex in `replace_imports()` could be tweaked to match unusual import lines, but I figure that's a separate issue. Although maybe the message should read "Could not replace the star imports for ..."?