### PR TITLE
Fix the line wrapping logic

### DIFF
--- a/removestar/removestar.py
+++ b/removestar/removestar.py
@@ -122,7 +122,7 @@ def replace_imports(code, repls, *, max_line_length=100, file=None, verbose=Fals
             new_import = ""
         else:
             new_import = f"from {mod} import " + ', '.join(names)
-            if len(new_import) - len(names[-1]) > max_line_length:
+            if len(new_import) > max_line_length:
                 lines = []
                 line = f"from {mod} import ("
                 indent = ' '*len(line)

--- a/removestar/tests/test_removestar.py
+++ b/removestar/tests/test_removestar.py
@@ -1100,6 +1100,17 @@ from reallyreallylongmodulename import (longname1,
 from reallyreallylongmodulename import (longname1, longname2, longname3, longname4, longname5, longname6, longname7,
                                         longname8, longname9)''')
 
+    assert len("from reallyreallylongmodulename import longname1, longname2, longname3, longname4, longname5, longname6, longname7, longname8, longname9") == 136
+
+    assert replace_imports(code, repls, max_line_length=137) == code_fixed.format(imp='''\
+from reallyreallylongmodulename import longname1, longname2, longname3, longname4, longname5, longname6, longname7, longname8, longname9''')
+
+    assert replace_imports(code, repls, max_line_length=136) == code_fixed.format(imp='''\
+from reallyreallylongmodulename import longname1, longname2, longname3, longname4, longname5, longname6, longname7, longname8, longname9''')
+
+    assert replace_imports(code, repls, max_line_length=135) == code_fixed.format(imp='''\
+from reallyreallylongmodulename import (longname1, longname2, longname3, longname4, longname5, longname6, longname7, longname8,
+                                        longname9)''')
 
     assert replace_imports(code, repls, max_line_length=200) == code_fixed.format(imp='''\
 from reallyreallylongmodulename import longname1, longname2, longname3, longname4, longname5, longname6, longname7, longname8, longname9''')


### PR DESCRIPTION
The logic for when the wrap a line the first time was based on not including
the last name in the line, which doesn't really make sense (I'm not sure why I
did it that way). Now the line is always wrapped if it is longer than the max
line length.

As discussed in #22.