### PR TITLE
Upgrade linter from pyflakes to ruff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyflakes pytest pytest-doctestplus
+          pip install ruff pytest pytest-doctestplus
       - name: Lint
         run: |
-          pyflakes .
+          ruff --select=A,B,E,F,PLC,PLE,PLW,SIM,W --ignore=E402,B023,B904,SIM115 --line-length=263 --statistics .
           python -We:invalid -We::SyntaxWarning -m compileall -f -q removestar/
       - name: Test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest pytest-doctestplus
+          pip install pyflakes pytest pytest-doctestplus ruff
       - name: Lint
         run: |
           ruff --select=A,B,E,F,PLC,PLE,PLW,SIM,W --ignore=E402,B023,B904,SIM115 --line-length=263 --statistics .

--- a/removestar/_version.py
+++ b/removestar/_version.py
@@ -113,7 +113,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     """
     rootdirs = []
 
-    for i in range(3):
+    for _ in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
             return {"version": dirname[len(parentdir_prefix):],
@@ -268,7 +268,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # TAG-NUM-gHEX
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
-            # unparseable. Maybe git-describe is misbehaving?
+            # unparsable. Maybe git-describe is misbehaving?
             pieces["error"] = ("unable to parse git-describe output: '%s'"
                                % describe_out)
             return pieces
@@ -495,7 +495,7 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for _ in cfg.versionfile_source.split('/'):
             root = os.path.dirname(root)
     except NameError:
         return {"version": "0+unknown", "full-revisionid": None,

--- a/removestar/removestar.py
+++ b/removestar/removestar.py
@@ -61,10 +61,9 @@ def fix_code(code, *, file, max_line_length=100, verbose=False, quiet=False, all
             if not quiet:
                 print(f"Warning: {file}: could not find import for '{name}'", file=sys.stderr)
             continue
-        if len(mods) > 1:
-            if not quiet:
-                print(f"Warning: {file}: '{name}' comes from multiple modules: {', '.join(map(repr, mods))}. Using '{mods[-1]}'.",
-                  file=sys.stderr)
+        if len(mods) > 1 and not quiet:
+            print(f"Warning: {file}: '{name}' comes from multiple modules: {', '.join(map(repr, mods))}. Using '{mods[-1]}'.",
+              file=sys.stderr)
 
         repls[mods[-1]].append(name)
 
@@ -194,7 +193,7 @@ def is_noqa_comment_allowing_star_import(comment):
     Check if a comment string is a Flake8 noqa comment that permits star imports
 
     The codes F401 and F403 are taken to permit star imports, as is a noqa
-    coment without codes.
+    comment without codes.
 
     Example:
 

--- a/removestar/tests/test_removestar.py
+++ b/removestar/tests/test_removestar.py
@@ -1325,7 +1325,7 @@ f"""\
     for d in diffs:
         assert d in p.stdout, p.stdout
     for mod_path in unchanged:
-        assert '--- original/{directory}/{mod_path}' not in p.stdout
+        assert f'--- original/{directory}/{mod_path}' not in p.stdout
     cmp = dircmp(directory, directory_orig)
     assert _dirs_equal(cmp)
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -180,7 +180,7 @@ two common reasons why `setup.py` might not be in the root:
   `setup.cfg`, and `tox.ini`. Projects like these produce multiple PyPI
   distributions (and upload multiple independently-installable tarballs).
 * Source trees whose main purpose is to contain a C library, but which also
-  provide bindings to Python (and perhaps other langauges) in subdirectories.
+  provide bindings to Python (and perhaps other languages) in subdirectories.
 
 Versioneer will look for `.git` in parent directories, and most operations
 should get the right version string. However `pip` and `setuptools` have bugs
@@ -688,7 +688,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # TAG-NUM-gHEX
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
-            # unparseable. Maybe git-describe is misbehaving?
+            # unparsable. Maybe git-describe is misbehaving?
             pieces["error"] = ("unable to parse git-describe output: '%%s'"
                                %% describe_out)
             return pieces
@@ -1080,7 +1080,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # TAG-NUM-gHEX
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
-            # unparseable. Maybe git-describe is misbehaving?
+            # unparsable. Maybe git-describe is misbehaving?
             pieces["error"] = ("unable to parse git-describe output: '%s'"
                                % describe_out)
             return pieces
@@ -1141,9 +1141,8 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
     try:
         f = open(".gitattributes", "r")
         for line in f.readlines():
-            if line.strip().startswith(versionfile_source):
-                if "export-subst" in line.strip().split()[1:]:
-                    present = True
+            if line.strip().startswith(versionfile_source) and "export-subst" in line.strip().split()[1:]:
+                present = True
         f.close()
     except EnvironmentError:
         pass
@@ -1164,7 +1163,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     """
     rootdirs = []
 
-    for i in range(3):
+    for _ in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
             return {"version": dirname[len(parentdir_prefix):],


### PR DESCRIPTION
https://beta.ruff.rs is a superset of pyflakes and [many other Python linters](https://beta.ruff.rs/docs/rules) written in Rust for speed.
`ruff --fix` was also run to auto-fix
```
4	B007  	[*] Loop control variable `i` not used within loop body
2	SIM102	[*] Use a single `if` statement instead of nested `if` statements
```
Also ran `codespell -w` to fix some typos.  https://pypi.org/project/codespell