### PR TITLE
Ruff: Set upper limits on code complexity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.0
     hooks:
       - id: black-jupyter
 
@@ -24,7 +24,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.0.282"
+    rev: "v0.0.287"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,13 @@ include = [
 [tool.ruff]
 select = [
   "E", "F", "W", # flake8
-  "B", "B904",   # flake8-bugbear
-  "I",           # isort
+  "ASYNC",       # flake8-async
+  "B",           # flake8-bugbear
   "C4",          # flake8-comprehensions
+  "C9",          # mccabe cyclomatic complexity
+  "I",           # isort
   "ISC",         # flake8-implicit-str-concat
+  "PERF",        # flake8-perf
   "PGH",         # pygrep-hooks
   "PIE",         # flake8-pie
   "PL",          # pylint
@@ -74,18 +77,24 @@ select = [
   "YTT",         # flake8-2020
 ]
 extend-ignore = [
-  "E501",        # Line too long
-  "PLR0915",     # Too many statements
-  "PLR0913",     # Too many arguments to function call
-  "T201",        # Print statements
-  "B904",        # Raise exception with `raise ... from err`
   "B023",        # Function definition does not bind loop variable
+  "B904",        # Raise exception with `raise ... from err`
+  "PLW1510",     # `subprocess.run` without explicit `check` argument
+  "T201",        # Print statements
 ]
+line-length = 177  # Default is 88
 src = ["src"]
 unfixable = [
-  "T20",  # Removes print statements
   "F841", # Removes unused variables
+  "T20",  # Removes print statements
 ]
+
+[tool.ruff.mccabe]
+max-complexity = 14  # Default is 10
+
+[tool.ruff.pylint]
+max-args = 6  # Default is 5
+max-statements = 177  # Default is 50
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/removestar/removestar.py
+++ b/removestar/removestar.py
@@ -25,11 +25,11 @@ def names_to_replace(checker):
 
 
 def star_imports(checker):
-    stars = []
-    for message in checker.messages:
-        if isinstance(message, ImportStarUsed):
-            stars.append(message.message_args[0])
-    return stars
+    return [
+        message.message_args[0]
+        for message in checker.messages
+        if isinstance(message, ImportStarUsed)
+    ]
 
 
 def fix_code(


### PR DESCRIPTION
By setting upper limits on code complexity we can use the code review process to force those who want to increase complexity to justify why that complexity is required.  These can be metrics for continuous improvement.

```
tool.ruff.line-length = 171  # Default is 88
tool.ruff.mccabe.max-complexity = 14  # Default is 10
tool.ruff.pylint.max-args = 6  # Default is 5
tool.ruff.pylint.max-statements = 177  # Default is 50
```

Also added ruff rules for `ASYNC` and `PERF` and fixed:
```
removestar/removestar.py:31:13: PERF401 Use a list comprehension to create a transformed list
```