### PR TITLE
Fix pytest config to run doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ addopts = [
     "--doctest-modules"
 ]
 testpaths = [
+    "removestar",
     "tests",
 ]
 log_cli_level = "DEBUG"


### PR DESCRIPTION
Present state: as the source code is not configured as a test path, the doc tests do not run locally or in CI.

```console
configfile: pyproject.toml
testpaths: tests
plugins: doctestplus-1.1.0
collected 90 items                                                                   

tests/test_removestar.py ..................................................... [ 58%]
...................................                                            [ 97%]
tests/test_removestar_nb.py ..                                                 [100%]

================================= 90 passed in 7.83s =================================
```

Change post-configuration:

```console
configfile: pyproject.toml
testpaths: removestar, tests
plugins: doctestplus-1.1.0
collected 93 items                                                                   

removestar/removestar.py s..                                                   [  3%]
tests/test_removestar.py ..................................................... [ 60%]
...................................                                            [ 97%]
tests/test_removestar_nb.py ..                                                 [100%]

=========================== 92 passed, 1 skipped in 6.46s ============================
```