### PR TITLE
Valid pre-commit tag in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or add `removestar` in `.pre-commit-config.yaml` -
 
 ```yaml
 - repo: https://github.com/asmeurer/removestar
-  rev: v1.4
+  rev: "1.5"
   hooks:
     - id: removestar
       args: [-i] # See docs for all args (-i edits file in-place)


### PR DESCRIPTION
The present pre-commit example contains an invalid git tag for removestar resulting in the following error.

```console
An unexpected error has occurred: CalledProcessError: command: ('/usr/local/bin/git', 'checkout', 'v1.4')
return code: 1
stdout: (none)
stderr:
    error: pathspec 'v1.4' did not match any file(s) known to git
Check the log at /Users/KieranRyan/.cache/pre-commit/pre-commit.log
```

removestar does not use the 'v' prefix in its tag names. Thus, updating the README tag version to reflect.