### PR TITLE
pre-commit autoupdate && pre-commit run --all-files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -19,7 +19,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.7"
+    rev: "v0.8.0"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
@@ -49,7 +49,7 @@ repos:
         exclude: assets/js/webapp\.js
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.18.0
+    rev: 1.19.1
     hooks:
       - id: blacken-docs
         args: ["-E"]

--- a/removestar/__main__.py
+++ b/removestar/__main__.py
@@ -155,7 +155,7 @@ def main():  # noqa: PLR0912, C901
             and importlib.util.find_spec("nbconvert") is not None
             and importlib.util.find_spec("nbformat") is not None
         ):
-            tmp_file = tempfile.NamedTemporaryFile()
+            tmp_file = tempfile.NamedTemporaryFile()  # noqa: SIM115
             tmp_path = tmp_file.name
 
             with open(file) as f:

--- a/tests/test_removestar_nb.py
+++ b/tests/test_removestar_nb.py
@@ -31,7 +31,7 @@ def prepare_nb(output_path="_test.ipynb"):
     with open(output_path, "w") as f:
         nbf.write(nb, f)
 
-    tmp_file = tempfile.NamedTemporaryFile()
+    tmp_file = tempfile.NamedTemporaryFile()  # noqa: SIM115
     tmp_path = tmp_file.name
 
     with open(output_path) as f:


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.6.0 -> v5.0.0
[https://github.com/astral-sh/ruff-pre-commit] updating v0.5.7 -> v0.8.0
[https://github.com/codespell-project/codespell] already up to date!
[https://github.com/pre-commit/mirrors-prettier] already up to date!
[https://github.com/asottile/blacken-docs] updating 1.18.0 -> 1.19.1
[https://github.com/pre-commit/pygrep-hooks] already up to date!
```
% `pre-commit run --all-files`