### PR TITLE
rm support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 dynamic = ["version"]
 description = "A tool to automatically replace 'import *' imports with explicit imports in files"
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
   { name = "Aaron Meurer", email = "asmeurer@gmail.com" },
 ]
@@ -22,7 +22,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/removestar/removestar.py
+++ b/removestar/removestar.py
@@ -339,7 +339,7 @@ def get_mod_filename(mod, directory):
     return filename
 
 
-@lru_cache()
+@lru_cache
 def get_module_names(mod, directory, *, allow_dynamic=True, _found=()):
     """
     Get the names defined in the module 'mod'


### PR DESCRIPTION
GitHub Actions do not have Python 3.7 installed out of the box anymore.